### PR TITLE
Remove redundant dependency

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -229,7 +229,7 @@ function tcx_customizer_live_preview() {
 	wp_enqueue_script(
 		'tcx-theme-customizer',
 		get_template_directory_uri() . '/js/theme-customizer.js',
-		array( 'jquery', 'customize-preview' ),
+		array( 'customize-preview' ),
 		'1.0.0',
 		true
 	);


### PR DESCRIPTION
The `jquery` dependency is redundant. `customize-preview` is registered with a dependency of `customize-base`, and that in turn is registered with a dependency of `jquery` among others.

See https://github.com/WordPress/WordPress/blob/e4a574fc876d9dfaf5604bc6c14efb5f3bd53eb9/wp-includes/script-loader.php#L388